### PR TITLE
[Expandable]: Resize height without behavior when

### DIFF
--- a/docs/Display/Expandable.md
+++ b/docs/Display/Expandable.md
@@ -59,6 +59,7 @@ By it's own the `Expandable` doesn't provide any appearance. It need to be custo
 ## Properties
 
 - `expanded`: **true** to expand the **Expandable**. *Default: false.*
+- `animationOnDelegateHeight`: **true** to enable animation on delegate height changed. *Default: false*.
 
 ## Examples
 
@@ -158,3 +159,13 @@ Qaterial.Expandable
 ```
 
 [QaterialOnline](https://tinyurl.com/y6nwwy5d)
+
+### Dynamic Height
+
+![expandableanimation](https://user-images.githubusercontent.com/17255804/88485962-8e627b80-cf7a-11ea-9ba2-c009687dc20b.gif)
+
+By default if the height of the delegate is changing, the expandable is immediately replicating the change without animation. This is very useful for example an expandable is inside an expandable.
+
+This behavior can be enabled with `animationOnDelegateHeight`.
+
+[QaterialOnline](https://tinyurl.com/y2d6gdka)

--- a/docs/Display/Expandable.md
+++ b/docs/Display/Expandable.md
@@ -56,6 +56,10 @@ By it's own the `Expandable` doesn't provide any appearance. It need to be custo
 - `delegate`: `Component` display when `expanded` is **true** with `animation`.
 - `animation`: Behavior on `delegate` height. There is a default implementation for that.
 
+When `header` component is loaded, the loaded item can be accessed thru `headerItem`.
+
+When `delegate` component is loaded, the loaded item can be accessed thru `delegateItem`.
+
 ## Properties
 
 - `expanded`: **true** to expand the **Expandable**. *Default: false.*

--- a/examples/Display - Expandable - DynamicHeight.qml
+++ b/examples/Display - Expandable - DynamicHeight.qml
@@ -1,0 +1,83 @@
+import QtQuick 2.0
+import Qaterial 1.0 as Qaterial
+
+Row
+{
+  id: root
+  property bool expanded: true
+  spacing: 16
+
+  Component
+  {
+    id: headerComponent
+    Qaterial.ItemDelegate
+    {
+      id: _header
+      text: "Header"
+      onClicked: () => root.expanded = !root.expanded
+
+      contentItem: Qaterial.Label
+      {
+        text: parent.text
+        textType: Qaterial.Style.TextType.Title
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+      }
+
+      Qaterial.DebugRectangle { anchors.fill: parent; border.color: Qaterial.Style.green }
+    }
+  }
+
+  Component
+  {
+    id: delegateComponent
+
+    Qaterial.Label
+    {
+      id: delegate
+      text: `Height : ${height.toFixed(0)}`
+      textType: Qaterial.Style.TextType.Title
+      horizontalAlignment: Text.AlignHCenter
+      verticalAlignment: Text.AlignVCenter
+      height: 100
+
+      SequentialAnimation
+      {
+          running: true
+          loops: Animation.Infinite
+          PauseAnimation { duration: 1000 }
+          NumberAnimation { target: delegate; property: "height"; to: 200; duration: 1000 }
+          PauseAnimation { duration: 1000 }
+          NumberAnimation { target: delegate; property: "height"; to: 50; duration: 500 }
+          PauseAnimation { duration: 500 }
+          NumberAnimation { target: delegate; property: "height"; to: 100; duration: 0 }
+          PauseAnimation { duration: 500 }
+          NumberAnimation { target: delegate; property: "height"; to: 150; duration: 0 }
+          PauseAnimation { duration: 500 }
+          NumberAnimation { target: delegate; property: "height"; to: 200; duration: 0 }
+          PauseAnimation { duration: 500 }
+          NumberAnimation { target: delegate; property: "height"; to: 150; duration: 0 }
+          PauseAnimation { duration: 500 }
+          NumberAnimation { target: delegate; property: "height"; to: 100; duration: 0 }
+      }
+
+      Qaterial.DebugRectangle { anchors.fill: parent; border.color: Qaterial.Style.amber }
+    }
+  }
+
+  Qaterial.Expandable
+  {
+    expanded: root.expanded
+    header: headerComponent
+    delegate: delegateComponent
+  } // Expandable
+
+  Qaterial.Expandable
+  {
+    expanded: root.expanded
+    header: headerComponent
+    delegate: delegateComponent
+    animationOnDelegateHeight: true
+  } // Expandable
+}
+

--- a/qml/Expandable.qml
+++ b/qml/Expandable.qml
@@ -47,6 +47,12 @@ Item
 
   property bool animationOnDelegateHeight
 
+  // Access to the loaded header item
+  readonly property Item headerItem: _headerLoader.item
+
+  // Access to the loaded delegateItem
+  readonly property Item delegateItem: _delegateLoader.item
+
   implicitWidth: Qaterial.Style.delegate.implicitWidth
   implicitHeight: _headerLoader.height + _delegateClipper.height
 


### PR DESCRIPTION
![expandableanimation](https://user-images.githubusercontent.com/17255804/88485962-8e627b80-cf7a-11ea-9ba2-c009687dc20b.gif)

By default if the height of the delegate is changing, the expandable is immediately replicating the change without animation. This is very useful for example an expandable is inside an expandable.

This behavior can be enabled with `animationOnDelegateHeight`.