### PR TITLE
[FolderTreeView]: FolderTreeView & FolderTreeViewItem

### DIFF
--- a/docs/IO/FolderTreeModel.md
+++ b/docs/IO/FolderTreeModel.md
@@ -9,6 +9,54 @@ title: 📁 FolderTreeModel
 
 `FolderTreeModel` mimic the API of `FolderListModel` but already exposed for a `TreeView`.
 
-*todo doc*.
+[QaterialOnline](https://tinyurl.com/y2sg6xp3)
+
+## FolderTreeModel
+
+### Properties
+
+| Property          | Type         | Default    | Description                                                  |
+| :---------------- | :----------- | :--------- | :----------------------------------------------------------- |
+| path              | `url`        | *empty*    | The path property holds a URL for the folder that the model currently provides. |
+| nameFilters       | `stringlist` | *empty*    | The nameFilters property contains a list of file name filters. The filters may include the ? and * wildcards. Example : `nameFilters: ["*.png", "*.jpg"]` |
+| caseSensitive     | `bool`       | *true*     | Use case sensitive pattern matching.                         |
+| showDrives        | `bool`       | *true*     | If true, drives are included in the model.                   |
+| showDirs          | `bool`       | *true*     | If true, directories are included in the model; otherwise only files are included. |
+| showFiles         | `bool`       | *true*     | If true, files are included in the model; otherwise only directories are included. |
+| showDirsFirst     | `bool`       | *true*     | If true, if directories are included in the model they will always be shown first, then the files. |
+| showDot           | `bool`       | *false*    | If true, the "." directory is included in the model; otherwise it is excluded. |
+| showDotDot        | `bool`       | *false*    | If true, the ".." directory is included in the model; otherwise it is excluded. |
+| showDotAndDotDot  | `bool`       | *false*    | If true, the "." and ".." directories are included in the model; otherwise they are excluded. |
+| showHidden        | `bool`       | *false*    | If true, hidden files and directories are included in the model; otherwise they are excluded. |
+| showOnlyReadable  | `bool`       | *false*    | If true, only readable files and directories are shown; otherwise all files and directories are shown. |
+| sortCaseSensitive | `bool`       | *true*     | If set to true, the sort is case sensitive. This property is true by default. |
+| sortReversed      | `bool`       | *false*    | If set to true, reverses the sort order. The default is false. |
+| sortField         | `int`        | *Unsorted* | The sortField property contains field to use for sorting. sortField may be one of:<br/>- FolderTreeModel.Unsorted<br/>- FolderTreeModel.Name<br/>- FolderTreeModel.Time<br/>- FolderTreeModel.Size<br/>- FolderTreeModel.Type |
+| status            | `int`        | *Null*     | This property holds the status of folder reading. It can be one of:<br/>- FolderTreeModel.Null - no folder has been set<br/>- FolderTreeModel.Ready - the folder has been loaded<br/>- FolderTreeModel.Loading - the folder is currently being loaded |
+
+### Readonly Properties
+
+| Property             | Type     | Description                                                  |
+| -------------------- | -------- | ------------------------------------------------------------ |
+| fileName             | `string` | Returns the name of the file, excluding the path.            |
+| filePath             | `string` | Returns the file name, including the path (which is absolute). |
+| fileBaseName         | `string` | Returns the base name of the file without the path.<br/>The base name consists of all characters in the file up to (but not including) the first '.' character.<br/>Example : "/tmp/archive.tar.gz" baseName is "archive"<br/>The base name of a file is computed equally on all platforms, independent of file naming conventions (e.g., ".bashrc" on Unix has an empty base name, and the suffix is "bashrc"). |
+| fileCompleteBaseName | `string` | Returns the complete base name of the file without the path.<br/>The complete base name consists of all characters in the file up to (but not including) the last '.' character.<br/>Example : "/tmp/archive.tar.gz" baseName is "archive.tar" |
+| fileSuffix           | `string` | Returns the suffix (extension) of the file.<br/>The suffix consists of all characters in the file after (but not including) the last '.'.<br/>Example : "/tmp/archive.tar.gz" return "gz"<br/>The suffix of a file is computed equally on all platforms, independent of file naming conventions (e.g., ".bashrc" on Unix has an empty base name, and the suffix is "bashrc"). |
+| fileCompleteSuffix   | `string` | Returns the complete suffix (extension) of the file.<br/>The complete suffix consists of all characters in the file after(but not including) the first '.'.<br/>Example : "/tmp/archive.tar.gz" return "tar.gz" |
+| fileSize             | `int64`  | Returns the file size in bytes. If the file does not exist or cannot be fetched, 0 is returned.<br/>If the file is a symlink, the size of the target file is returned (not the symlink). |
+| fileModified         | `date`   | Returns the date and local time when the file was last modified.<br/>If the file is a symlink, the time of the target file is returned (not the symlink). |
+| fileAccessed         | `date`   | Returns the date and local time when the file was last read (accessed).<br/>On platforms where this information is not available, returns the same as fileModified().<br/>If the file is a symlink, the time of the target file is returned (not the symlink). |
+| fileIsDir            | `bool`   | Returns true if this object points to a directory or to a symbolic link to a directory; otherwise returns false.<br/>If the file is a symlink, this function returns true if the target is a directory (not the symlink). |
+
+### Api
+
+By default the model isn't populated, it's up to the user to explicitly call `fetch`.
+
+> Warning : For now the code is only run in main thread. This will result in ui freeze.
+
+## FolderTreeView
+
+FolderTreeView provide a `TreeView` ready to explore a folder and subfolder. The default itemDelegate is a `FolderTreeViewItem`.
 
 [QaterialOnline](https://tinyurl.com/y2sg6xp3)

--- a/examples/Navigation - FolderTreeView.qml
+++ b/examples/Navigation - FolderTreeView.qml
@@ -1,0 +1,41 @@
+import QtQuick 2.14
+import QtQml 2.14
+
+import Qaterial 1.0 as Qaterial
+
+Qaterial.FolderTreeView
+{
+  id: treeView
+
+  width: 300
+  height: parent ? Math.min(contentHeight, parent.height) : contentHeight
+
+  // sortField: Qaterial.FolderTreeModel.Type/Name/Size/Time
+  // sortReversed: true
+  // sortCaseSensitive: false
+  //
+  // showDotAndDotDot: true
+  // showDrives: false
+  // showDirs: false
+  // showFiles: false
+  // showHidden: true
+  // showOnlyReadable: true
+  //
+  // nameFilters: [ "*.qml", "*.cpp" ]
+  // caseSensitive: true
+  //
+  // path: file:///Path/To/Folder
+  path: "file://C:/Users/olivi/Documents/dev/Naostage/Kratos/build/_deps/qaterial-src"
+
+  property QtObject selectedElement
+
+  itemDelegate: Qaterial.FolderTreeViewItem
+  {
+    highlighted: treeView.selectedElement === model
+    onAccepted: function(path)
+    {
+      console.log(`Accept path ${path}`)
+      treeView.selectedElement = model
+    }
+  }
+}

--- a/qml/FolderTreeView.qml
+++ b/qml/FolderTreeView.qml
@@ -1,0 +1,42 @@
+// Copyright Olivier Le Doeuff 2020 (C)
+
+import QtQml 2.14
+import QtQuick 2.14
+
+import Qaterial 1.0 as Qaterial
+
+Qaterial.TreeView
+{
+  id: treeView
+
+  property alias path: folderTreeModel.path
+  property alias nameFilters: folderTreeModel.nameFilters
+  property alias caseSensitive: folderTreeModel.caseSensitive
+  property alias showDrives: folderTreeModel.showDrives
+  property alias showDirs: folderTreeModel.showDirs
+  property alias showFiles: folderTreeModel.showFiles
+  property alias showDirsFirst: folderTreeModel.showDirsFirst
+  property alias showDot: folderTreeModel.showDot
+  property alias showDotDot: folderTreeModel.showDotDot
+  property alias showDotAndDotDot: folderTreeModel.showDotAndDotDot
+  property alias showHidden: folderTreeModel.showHidden
+  property alias showOnlyReadable: folderTreeModel.showOnlyReadable
+  property alias sortCaseSensitive: folderTreeModel.sortCaseSensitive
+  property alias sortReversed: folderTreeModel.sortReversed
+  property alias sortField: folderTreeModel.sortField
+  property alias status: folderTreeModel.status
+
+  implicitWidth: 300
+  implicitHeight: contentHeight
+
+  model: folderTreeModel
+  itemDelegate: Qaterial.FolderTreeViewItem { }
+
+  Qaterial.FolderTreeModel
+  {
+    id: folderTreeModel
+
+    onPathChanged: function() { if(treeView.model === folderTreeModel) fetch() }
+    Component.onCompleted: function() { if(treeView.model === folderTreeModel) fetch() }
+  }
+}

--- a/qml/FolderTreeViewItem.qml
+++ b/qml/FolderTreeViewItem.qml
@@ -2,10 +2,12 @@
 
 import QtQml 2.14
 import QtQuick 2.14
+import QtQuick.Templates 2.12 as T
+import QtQuick.Controls 2.12
 
 import Qaterial 1.0 as Qaterial
 
-Qaterial.ItemDelegate
+T.ItemDelegate
 {
   id: control
 
@@ -103,9 +105,14 @@ Qaterial.ItemDelegate
     return Qaterial.Icons.codeTags
   }
 
-  height: 24
+  implicitWidth: Math.max(background ? implicitBackgroundWidth : 0,
+                          implicitContentWidth + leftPadding + rightPadding)
+  implicitHeight: Math.max(background ? implicitBackgroundHeight : 0,
+                           Math.max(implicitContentHeight,
+                                    indicator ? indicator.implicitHeight : 0) + topPadding + bottomPadding) + bottomInset
+
   spacing: 8
-  leftPadding: depth*Qaterial.Style.card.horizontalPadding + 4
+  leftPadding: depth*Qaterial.Style.card.horizontalPadding + 12
 
   text: model ? model.fileName : ""
   property color color:
@@ -203,4 +210,13 @@ Qaterial.ItemDelegate
     x: 2
     y: 2
   }
+
+  background: Qaterial.ListDelegateBackground
+  {
+    implicitHeight: 24
+    color: control.highlighted ? Qaterial.Style.backgroundColor : "transparent"
+    pressed: control.pressed
+    rippleActive: control.down || control.visualFocus || control.hovered
+    rippleAnchor: control
+  } // ListDelegateBackground
 }

--- a/qml/FolderTreeViewItem.qml
+++ b/qml/FolderTreeViewItem.qml
@@ -1,0 +1,206 @@
+// Copyright Olivier Le Doeuff 2020 (C)
+
+import QtQml 2.14
+import QtQuick 2.14
+
+import Qaterial 1.0 as Qaterial
+
+Qaterial.ItemDelegate
+{
+  id: control
+
+  // Injected by the TreeView
+  property QtObject model
+
+  // Injected by the TreeView
+  property int depth
+
+  // Injected by the TreeView
+  property int index
+
+  property Qaterial.FolderTreeModel folderTreeModel: model ? model.qtObject : null
+
+  // Called when a user click on the file
+  signal accepted(string path)
+
+  readonly property string extensionIcon:
+  {
+    if(!model)
+      return ""
+
+    const ext = model.fileCompleteSuffix
+
+    if(model.isDir)
+      return model.expanded ? Qaterial.Icons.folderOutline : Qaterial.Icons.folder
+
+    if(model.fileBaseName === "")
+      return Qaterial.Icons.asterisk
+
+    if(ext == 'cpp' || ext == 'hpp' || ext == 'cxx' || ext == 'hxx' || ext == 'cc')
+      return Qaterial.Icons.languageCpp
+
+    if(ext == 'c' || ext == 'h')
+      return Qaterial.Icons.languageC
+
+    if(ext == 'cs')
+      return Qaterial.Icons.languageCsharp
+
+    if(ext == 'css')
+      return Qaterial.Icons.languageCss3
+
+    if(ext == 'go')
+      return Qaterial.Icons.languageGo
+
+    if(ext == 'html')
+      return Qaterial.Icons.languageHtml
+
+    if(ext == 'java')
+      return Qaterial.Icons.languageJava
+
+    if(ext == 'js')
+      return Qaterial.Icons.languageJavascript
+
+    if(ext == 'kt')
+      return Qaterial.Icons.languageKotlin
+
+    if(ext == 'lua')
+      return Qaterial.Icons.languageLua
+
+    if(ext == 'md')
+      return Qaterial.Icons.languageMarkdown
+
+    if(ext == 'php')
+      return Qaterial.Icons.languagePhp
+
+    if(ext == 'py')
+      return Qaterial.Icons.languagePython
+
+    if(ext == 'ruby')
+      return Qaterial.Icons.languageRuby
+
+    if(ext == 'ts')
+      return Qaterial.Icons.languageTypescript
+
+    if(ext == 'swift')
+      return Qaterial.Icons.languageSwift
+
+    if(ext == 'xaml')
+      return Qaterial.Icons.languageXaml
+
+    if(ext == 'txt')
+      return Qaterial.Icons.text
+
+    if(ext == 'json')
+      return Qaterial.Icons.text
+
+
+    if(ext.includes('vcxproj') || ext == 'sln')
+      return Qaterial.Icons.microsoftVisualStudioCode
+
+    if(ext == 'png' || ext == 'jpg' || ext == 'jpeg' || ext == 'svg')
+      return Qaterial.Icons.codeJson
+
+    return Qaterial.Icons.codeTags
+  }
+
+  height: 24
+  spacing: 8
+  leftPadding: depth*Qaterial.Style.card.horizontalPadding + 4
+
+  text: model ? model.fileName : ""
+  property color color:
+  {
+     if(model && model.isDir && model.expanded)
+      return Qaterial.Style.accentColor
+
+    if(highlighted)
+        return Qaterial.Style.accentColor
+
+    if(hovered)
+        return Qaterial.Style.primaryTextColor()
+
+    return Qaterial.Style.hintTextColor()
+  }
+
+  icon.source: extensionIcon
+  icon.color:
+  {
+    if(highlighted || hovered)
+      return Qaterial.Style.accentColor
+
+     if(model && model.isDir && model.expanded)
+      return Qaterial.Style.accentColor
+
+    Qaterial.Style.hintTextColor()
+  }
+
+  onClicked: function()
+  {
+    if(!model)
+      return
+
+    if(model.isDir)
+    {
+      // fetch content of folder if expand is about to happen
+      if(!model.expanded && folderTreeModel)
+        folderTreeModel.fetch()
+
+      // Then expand or retract
+      model.expanded = !model.expanded
+    }
+    else
+    {
+      control.accepted(`file:///${model.filePath}`)
+    }
+  }
+
+  // Qaterial.DebugRectangle { anchors.fill: parent; border.color: "red" }
+
+  contentItem: Item
+  {
+    implicitHeight: Math.max(fileIcon.implicitHeight, fileLabel.implicitHeight)
+
+    // Qaterial.DebugRectangle { anchors.fill: parent }
+
+    Qaterial.Icon
+    {
+      id: fileIcon
+
+      anchors.verticalCenter: parent.verticalCenter
+
+      visible: parent.width > (width + control.leftPadding)
+      size: parent.height - 4
+
+      icon: control.icon.source
+      color: control.icon.color
+    }
+
+    Qaterial.Label
+    {
+      id: fileLabel
+
+      anchors.verticalCenter: parent.verticalCenter
+
+      x: fileIcon.width + control.spacing
+      width: parent.width - fileIcon.width - control.spacing
+
+      text: control.text
+      textType: Qaterial.Style.TextType.Caption
+      elide: Text.ElideRight
+      verticalAlignment: Text.AlignVCenter
+
+      color: control.color
+    }
+  }
+
+  // Selected indicator
+  Rectangle
+  {
+    visible: control.highlighted
+    color: Qaterial.Style.accentColor
+    height: control.height - 4
+    width: 2
+    x: 2
+    y: 2
+  }
+}

--- a/qml/Icon.qml
+++ b/qml/Icon.qml
@@ -17,8 +17,8 @@ Item
   property url icon
   property real size: 24
 
-  width: size
-  height: size
+  implicitWidth: size
+  implicitHeight: size
 
   Image
   {

--- a/qml/Qaterial.qrc
+++ b/qml/Qaterial.qrc
@@ -78,6 +78,8 @@
     <file>FixedTabBar.qml</file>
     <file>FlatButton.qml</file>
     <file>FlatFabButton.qml</file>
+    <file>FolderTreeView.qml</file>
+    <file>FolderTreeViewItem.qml</file>
     <file>Fonts</file>
     <file>Frame.qml</file>
     <file>GradientSlider.qml</file>

--- a/qml/qmldir
+++ b/qml/qmldir
@@ -79,6 +79,8 @@ FabIconLabel 1.0 FabIconLabel.qml
 FixedTabBar 1.0 FixedTabBar.qml
 FlatButton 1.0 FlatButton.qml
 FlatFabButton 1.0 FlatFabButton.qml
+FolderTreeView 1.0 FolderTreeView.qml
+FolderTreeViewItem 1.0 FolderTreeViewItem.qml
 Frame 1.0 Frame.qml
 GradientSlider 1.0 GradientSlider.qml
 GridLabelsX 1.0 GridLabelsX.qml

--- a/src/FolderTreeModel.cpp
+++ b/src/FolderTreeModel.cpp
@@ -136,14 +136,11 @@ void FolderTreeModel::initializeBindings()
 
 FolderTreeModel* FolderTreeModel::children() { return this; }
 
-QUrl FolderTreeModel::path() const
-{
-    return _path;
-}
+QUrl FolderTreeModel::path() const { return _path; }
 
 bool FolderTreeModel::setPath(const QUrl& value)
 {
-    if (value != _path)
+    if(value != _path)
     {
         _path = value;
         auto pathString = _path.path();
@@ -168,10 +165,7 @@ bool FolderTreeModel::setPath(const QUrl& value)
     return false;
 }
 
-void FolderTreeModel::resetPath()
-{
-    setPath({});
-}
+void FolderTreeModel::resetPath() { setPath({}); }
 
 void FolderTreeModel::fetch()
 {
@@ -219,19 +213,28 @@ void FolderTreeModel::fetch()
     default:;
     }
 
+    const auto appendFolder = [&](QFileInfoList& list)
+    { list += currentDirectory.entryInfoList(folderFilter, sortFlags); };
+    const auto secondFetchForFolderIsRequired = !nameFilters().empty() && showDirs();
+
     // Fetch all entries and append in one operation
-    auto fileInfoList = currentDirectory.entryInfoList(nameFilters(), filters, sortFlags);
-    if(!nameFilters().empty() && showDirs())
-        fileInfoList += currentDirectory.entryInfoList(folderFilter, sortFlags);
+    QFileInfoList fileInfoList;
+    if(secondFetchForFolderIsRequired && showDirsFirst())
+        appendFolder(fileInfoList);
+
+    fileInfoList += currentDirectory.entryInfoList(nameFilters(), filters, sortFlags);
+
+    if(secondFetchForFolderIsRequired && !showDirsFirst())
+        appendFolder(fileInfoList);
 
     QList<FolderTreeModel*> folders;
 
     for(const auto& fileInfo: fileInfoList)
     {
-        folders.append(
-            new FolderTreeModel(path().path() + '/' + fileInfo.fileName(), fileInfo.fileName(), fileInfo.absoluteFilePath(),
-                fileInfo.baseName(), fileInfo.completeBaseName(), fileInfo.suffix(), fileInfo.completeSuffix(),
-                fileInfo.size(), fileInfo.lastModified(), fileInfo.lastRead(), fileInfo.isDir(), this));
+        folders.append(new FolderTreeModel(path().path() + '/' + fileInfo.fileName(), fileInfo.fileName(),
+            fileInfo.absoluteFilePath(), fileInfo.baseName(), fileInfo.completeBaseName(), fileInfo.suffix(),
+            fileInfo.completeSuffix(), fileInfo.size(), fileInfo.lastModified(), fileInfo.lastRead(), fileInfo.isDir(),
+            this));
     }
 
     if(!folders.empty())

--- a/tools/HotReload/lib/qml/HotReload.qml
+++ b/tools/HotReload/lib/qml/HotReload.qml
@@ -379,7 +379,7 @@ Qaterial.Page
           itemDelegate: Qaterial.FolderTreeViewItem
           {
             id: control
-            highlighted: model && model.filePath === window.currentFilePath
+            highlighted: model && model.filePath === root.currentFilePath
             onAccepted: function(path)
             {
               root.loadFile(path)

--- a/tools/HotReload/lib/qml/HotReload.qml
+++ b/tools/HotReload/lib/qml/HotReload.qml
@@ -355,7 +355,7 @@ Qaterial.Page
         SplitView.preferredWidth: 200
         SplitView.minimumWidth: 0
 
-        Qaterial.TreeView
+        Qaterial.FolderTreeView
         {
           id: treeView
           anchors.fill: parent
@@ -373,103 +373,16 @@ Qaterial.Page
 
           property QtObject selectedElement
 
-          model: Qaterial.FolderTreeModel
-          {
-            nameFilters: [ "*.qml", "*.hpp", "*.cpp", "*.qrc", "qmldir" ]
-            path: `file:${root.currentFolderPath}`
-            onPathChanged: () => fetch()
-            Component.onCompleted: () => fetch()
-          }
+          nameFilters: [ "*.qml" ]
+          path: `file:${root.currentFolderPath}`
 
-          itemDelegate: Qaterial.ItemDelegate
+          itemDelegate: Qaterial.FolderTreeViewItem
           {
             id: control
-
-            property QtObject model
-            property Qaterial.FolderTreeModel folderTreeModel: model ? model.qtObject : null
-            property int depth
-            property int index
-
-            readonly property bool selected: model && model.filePath === root.currentFilePath
-
-            height: 24
-            leftPadding: depth*Qaterial.Style.card.horizontalPadding + 4
-
-            contentItem: RowLayout
+            highlighted: model && model.filePath === window.currentFilePath
+            onAccepted: function(path)
             {
-              Qaterial.ColorIcon
-              {
-                visible: parent.width > (width + control.leftPadding)
-                source:
-                {
-                  if(!control.model)
-                    return ""
-
-                  if(control.model.isDir)
-                    return control.model.expanded ? Qaterial.Icons.folderOutline : Qaterial.Icons.folder
-                  return Qaterial.Icons.codeTags
-                }
-                color:
-                {
-                  if(control.selected || control.hovered)
-                    return Qaterial.Style.accentColor
-
-                   if(control.model && control.model.isDir && control.model.expanded)
-                    return Qaterial.Style.accentColor
-
-                  Qaterial.Style.hintTextColor()
-                }
-                Behavior on rotation { NumberAnimation { duration: 200; easing.type: Easing.OutQuart } }
-              }
-              Qaterial.Label
-              {
-                Layout.fillWidth: true
-                text: (control.model ? control.model.fileName : "")
-                textType: Qaterial.Style.TextType.Caption
-                elide: Text.ElideRight
-                verticalAlignment: Text.AlignVCenter
-
-                color:
-                {
-                   if(control.model && control.model.isDir && control.model.expanded)
-                    return Qaterial.Style.accentColor
-
-                  if(control.selected)
-                      return Qaterial.Style.accentColor
-                  if(control.hovered)
-                      return Qaterial.Style.primaryTextColor()
-                  return Qaterial.Style.hintTextColor()
-                }
-              }
-            }
-
-            Rectangle
-            {
-              visible: control.selected
-              color: Qaterial.Style.accentColor
-              height: control.height - 4
-              width: 2
-              x: 2
-              y: 2
-            }
-
-            onClicked: function()
-            {
-              if(!model)
-                return
-              if(model.isDir)
-              {
-                // fetch content of folder if expand is about to happen
-                if(!model.expanded)
-                  folderTreeModel.fetch()
-
-                // Then expand or retract
-                model.expanded = !model.expanded
-              }
-              else
-              {
-                root.loadFile(`file:///${model.filePath}`)
-              }
+              root.loadFile(path)
             }
           }
         } // TreeView


### PR DESCRIPTION
---
layout: default
title: 📁 FolderTreeModel
---

# 📁 FolderTreeModel

![folderTreeModel](https://user-images.githubusercontent.com/17255804/88556713-9deccd80-d029-11ea-97b7-4929753a4d85.gif)

`FolderTreeModel` mimic the API of `FolderListModel` but already exposed for a `TreeView`.

[QaterialOnline](https://tinyurl.com/y2sg6xp3)

## FolderTreeModel

### Properties

| Property          | Type         | Default    | Description                                                  |
| :---------------- | :----------- | :--------- | :----------------------------------------------------------- |
| path              | `url`        | *empty*    | The path property holds a URL for the folder that the model currently provides. |
| nameFilters       | `stringlist` | *empty*    | The nameFilters property contains a list of file name filters. The filters may include the ? and * wildcards. Example : `nameFilters: ["*.png", "*.jpg"]` |
| caseSensitive     | `bool`       | *true*     | Use case sensitive pattern matching.                         |
| showDrives        | `bool`       | *true*     | If true, drives are included in the model.                   |
| showDirs          | `bool`       | *true*     | If true, directories are included in the model; otherwise only files are included. |
| showFiles         | `bool`       | *true*     | If true, files are included in the model; otherwise only directories are included. |
| showDirsFirst     | `bool`       | *true*     | If true, if directories are included in the model they will always be shown first, then the files. |
| showDot           | `bool`       | *false*    | If true, the "." directory is included in the model; otherwise it is excluded. |
| showDotDot        | `bool`       | *false*    | If true, the ".." directory is included in the model; otherwise it is excluded. |
| showDotAndDotDot  | `bool`       | *false*    | If true, the "." and ".." directories are included in the model; otherwise they are excluded. |
| showHidden        | `bool`       | *false*    | If true, hidden files and directories are included in the model; otherwise they are excluded. |
| showOnlyReadable  | `bool`       | *false*    | If true, only readable files and directories are shown; otherwise all files and directories are shown. |
| sortCaseSensitive | `bool`       | *true*     | If set to true, the sort is case sensitive. This property is true by default. |
| sortReversed      | `bool`       | *false*    | If set to true, reverses the sort order. The default is false. |
| sortField         | `int`        | *Unsorted* | The sortField property contains field to use for sorting. sortField may be one of:<br/>- FolderTreeModel.Unsorted<br/>- FolderTreeModel.Name<br/>- FolderTreeModel.Time<br/>- FolderTreeModel.Size<br/>- FolderTreeModel.Type |
| status            | `int`        | *Null*     | This property holds the status of folder reading. It can be one of:<br/>- FolderTreeModel.Null - no folder has been set<br/>- FolderTreeModel.Ready - the folder has been loaded<br/>- FolderTreeModel.Loading - the folder is currently being loaded |

### Readonly Properties

| Property             | Type     | Description                                                  |
| -------------------- | -------- | ------------------------------------------------------------ |
| fileName             | `string` | Returns the name of the file, excluding the path.            |
| filePath             | `string` | Returns the file name, including the path (which is absolute). |
| fileBaseName         | `string` | Returns the base name of the file without the path.<br/>The base name consists of all characters in the file up to (but not including) the first '.' character.<br/>Example : "/tmp/archive.tar.gz" baseName is "archive"<br/>The base name of a file is computed equally on all platforms, independent of file naming conventions (e.g., ".bashrc" on Unix has an empty base name, and the suffix is "bashrc"). |
| fileCompleteBaseName | `string` | Returns the complete base name of the file without the path.<br/>The complete base name consists of all characters in the file up to (but not including) the last '.' character.<br/>Example : "/tmp/archive.tar.gz" baseName is "archive.tar" |
| fileSuffix           | `string` | Returns the suffix (extension) of the file.<br/>The suffix consists of all characters in the file after (but not including) the last '.'.<br/>Example : "/tmp/archive.tar.gz" return "gz"<br/>The suffix of a file is computed equally on all platforms, independent of file naming conventions (e.g., ".bashrc" on Unix has an empty base name, and the suffix is "bashrc"). |
| fileCompleteSuffix   | `string` | Returns the complete suffix (extension) of the file.<br/>The complete suffix consists of all characters in the file after(but not including) the first '.'.<br/>Example : "/tmp/archive.tar.gz" return "tar.gz" |
| fileSize             | `int64`  | Returns the file size in bytes. If the file does not exist or cannot be fetched, 0 is returned.<br/>If the file is a symlink, the size of the target file is returned (not the symlink). |
| fileModified         | `date`   | Returns the date and local time when the file was last modified.<br/>If the file is a symlink, the time of the target file is returned (not the symlink). |
| fileAccessed         | `date`   | Returns the date and local time when the file was last read (accessed).<br/>On platforms where this information is not available, returns the same as fileModified().<br/>If the file is a symlink, the time of the target file is returned (not the symlink). |
| fileIsDir            | `bool`   | Returns true if this object points to a directory or to a symbolic link to a directory; otherwise returns false.<br/>If the file is a symlink, this function returns true if the target is a directory (not the symlink). |

### Api

By default the model isn't populated, it's up to the user to explicitly call `fetch`.

> Warning : For now the code is only run in main thread. This will result in ui freeze.

## FolderTreeView

FolderTreeView provide a `TreeView` ready to explore a folder and subfolder. The default itemDelegate is a `FolderTreeViewItem`.

[QaterialOnline](https://tinyurl.com/y2sg6xp3)