### PR TITLE
[CMake]: Use versionless targets from Qt 5.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,13 +186,13 @@ target_link_libraries(${QATERIAL_TARGET} PRIVATE
 target_link_libraries(${QATERIAL_TARGET} PUBLIC
   spdlog
   QOlm
-  Qt5::Core
-  Qt5::Gui
-  Qt5::Svg
-  Qt5::Xml
-  Qt5::Qml
-  Qt5::Quick
-  Qt5::QuickControls2
+  Qt::Core
+  Qt::Gui
+  Qt::Svg
+  Qt::Xml
+  Qt::Qml
+  Qt::Quick
+  Qt::QuickControls2
 )
 
 set_target_properties(${QATERIAL_TARGET} PROPERTIES AUTORCC TRUE)

--- a/res/Fonts/CMakeLists.txt
+++ b/res/Fonts/CMakeLists.txt
@@ -57,11 +57,11 @@ add_library(${QATERIAL_TARGET}Fonts STATIC ${QATERIAL_FONTS_QML_QRC})
 set_target_properties(${QATERIAL_TARGET}Fonts PROPERTIES AUTORCC TRUE)
 
 target_link_libraries(${QATERIAL_TARGET}Fonts PRIVATE
-  Qt5::Core
-  Qt5::Gui
-  Qt5::Svg
-  Qt5::Xml
-  Qt5::Qml
+  Qt::Core
+  Qt::Gui
+  Qt::Svg
+  Qt::Xml
+  Qt::Qml
 )
 
 if(QATERIAL_FOLDER_PREFIX)

--- a/res/Icons/CMakeLists.txt
+++ b/res/Icons/CMakeLists.txt
@@ -64,11 +64,11 @@ add_library(${QATERIAL_TARGET}Icons STATIC ${QATERIAL_QML_ICONS_QRC} ${QATERIAL_
 set_target_properties(${QATERIAL_TARGET}Icons PROPERTIES AUTORCC TRUE)
 
 target_link_libraries(${QATERIAL_TARGET}Icons PRIVATE
-  Qt5::Core
-  Qt5::Gui
-  Qt5::Svg
-  Qt5::Xml
-  Qt5::Qml
+  Qt::Core
+  Qt::Gui
+  Qt::Svg
+  Qt::Xml
+  Qt::Qml
 )
 
 if(QATERIAL_FOLDER_PREFIX)

--- a/tools/HelloWorld/CMakeLists.txt
+++ b/tools/HelloWorld/CMakeLists.txt
@@ -32,7 +32,7 @@ if(QATERIAL_ENABLE_PCH AND COMMAND target_precompile_headers)
 endif()
 
 # Support Static Qt (this will be no longer necessary with qt6)
-get_target_property(QT_TARGET_TYPE Qt5::Core TYPE)
+get_target_property(QT_TARGET_TYPE Qt::Core TYPE)
 if(${QT_TARGET_TYPE} STREQUAL "STATIC_LIBRARY")
   qt_generate_qml_plugin_import(${QATERIAL_HELLOWORLD}
     QML_SRC ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tools/HotReload/lib/CMakeLists.txt
+++ b/tools/HotReload/lib/CMakeLists.txt
@@ -74,7 +74,7 @@ if(QATERIAL_ENABLE_PCH AND COMMAND target_precompile_headers)
   target_precompile_headers(${QATERIAL_HOTRELOAD_LIB} PRIVATE ${PROJECT_SOURCE_DIR}/include/Qaterial/Pch/Pch.hpp)
 endif()
 
-get_target_property(QT_TARGET_TYPE Qt5::Core TYPE)
+get_target_property(QT_TARGET_TYPE Qt::Core TYPE)
 if(${QT_TARGET_TYPE} STREQUAL "STATIC_LIBRARY")
   qt_generate_qml_plugin_import(${QATERIAL_HOTRELOAD_LIB}
     QML_SRC ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tools/HotReload/lib/CMakeLists.txt
+++ b/tools/HotReload/lib/CMakeLists.txt
@@ -44,25 +44,25 @@ find_package(Qt5 QUIET COMPONENTS
   Quick3DUtils)
 
 target_link_quiet_libraries(${QATERIAL_HOTRELOAD_LIB}
-  Qt5::Charts
-  Qt5::DataVisualization
-  Qt5::VirtualKeyboard
-  Qt5::WebChannel
-  Qt5::WebSockets
-  Qt5::WebEngine
+  Qt::Charts
+  Qt::DataVisualization
+  Qt::VirtualKeyboard
+  Qt::WebChannel
+  Qt::WebSockets
+  Qt::WebEngine
 
-  Qt5::3DCore
-  Qt5::3DRender
-  Qt5::3DInput
-  Qt5::3DLogic
-  Qt5::3DExtras
-  Qt5::3DAnimation
+  Qt::3DCore
+  Qt::3DRender
+  Qt::3DInput
+  Qt::3DLogic
+  Qt::3DExtras
+  Qt::3DAnimation
 
-  Qt5::Quick3D
-  Qt5::Quick3DAssetImport
-  Qt5::Quick3DRender
-  Qt5::Quick3DRuntimeRender
-  Qt5::Quick3DUtils)
+  Qt::Quick3D
+  Qt::Quick3DAssetImport
+  Qt::Quick3DRender
+  Qt::Quick3DRuntimeRender
+  Qt::Quick3DUtils)
 
 set_target_properties(${QATERIAL_HOTRELOAD_LIB} PROPERTIES
   FOLDER "${QATERIAL_FOLDER_PREFIX}/HotReload"


### PR DESCRIPTION
in order to facilitate transition to Qt6:

https://doc-snapshots.qt.io/qt6-dev/cmake-qt5-and-qt6-compatibility.html#versionless-targets