### PR TITLE
🔨 Fix unit test qml file research

### DIFF
--- a/tests/Loader/CMakeLists.txt
+++ b/tests/Loader/CMakeLists.txt
@@ -16,8 +16,7 @@ if(QATERIAL_ENABLE_PCH AND COMMAND target_precompile_headers)
   target_precompile_headers(${QATERIAL_TEST_LOADER} PRIVATE ${PROJECT_SOURCE_DIR}/src/Qaterial/Pch/Pch.hpp)
 endif()
 
-
-file(GLOB QML_FILES ${PROJECT_SOURCE_DIR}/qml/*.qml)
+file(GLOB_RECURSE QML_FILES ${PROJECT_SOURCE_DIR}/qml/*.qml)
 
 foreach(QML_FILE ${QML_FILES})
 


### PR DESCRIPTION
 (*.qml have been moved from qml/ to qml/Qaterial)

Let's use GLOB_RECURSE to fix it and keep compatibility if more folder are added to Qaterial