### PR TITLE
Icon img

### DIFF
--- a/examples/Display/Icon.qml
+++ b/examples/Display/Icon.qml
@@ -88,7 +88,6 @@ Column
         Qaterial.DebugRectangle { anchors.fill: parent }
       }
 
-
       Qaterial.Label
       {
         anchors.horizontalCenter: parent.horizontalCenter
@@ -117,6 +116,58 @@ Column
       {
         anchors.horizontalCenter: parent.horizontalCenter
         text: "large"
+      }
+    }
+  }
+
+  Row
+  {
+    anchors.horizontalCenter: parent.horizontalCenter
+
+    spacing: Qaterial.Style.largeSpacing
+
+    Column
+    {
+      anchors.bottom: parent.bottom
+
+      spacing: Qaterial.Style.smallSpacing
+
+      Qaterial.Icon
+      {
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        icon: "https://www.flaticon.com/svg/static/icons/svg/119/119591.svg"
+        color: "transparent"
+        size: Qaterial.Style.largeIcon
+      }
+
+      Qaterial.Label
+      {
+        anchors.horizontalCenter: parent.horizontalCenter
+        text: "transparent"
+      }
+    }
+
+    Column
+    {
+      anchors.bottom: parent.bottom
+
+      spacing: Qaterial.Style.smallSpacing
+
+      Qaterial.Icon
+      {
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        icon: "https://www.flaticon.com/svg/static/icons/svg/119/119591.svg"
+        color: "transparent"
+        size: Qaterial.Style.largeIcon
+        enabled: false
+      }
+
+      Qaterial.Label
+      {
+        anchors.horizontalCenter: parent.horizontalCenter
+        text: "disabled"
       }
     }
   }

--- a/examples/Display/Icon.qml
+++ b/examples/Display/Icon.qml
@@ -1,0 +1,123 @@
+import QtQuick 2.0
+import Qaterial 1.0 as Qaterial
+
+Column
+{
+  id: root
+
+  spacing: Qaterial.Style.largeSpacing
+
+  Row
+  {
+    anchors.horizontalCenter: parent.horizontalCenter
+
+    spacing: Qaterial.Style.largeSpacing
+
+    Column
+    {
+      spacing: Qaterial.Style.smallSpacing
+
+      Qaterial.Icon
+      {
+        anchors.horizontalCenter: parent.horizontalCenter
+        icon: Qaterial.Icons.abacus
+      }
+
+      Qaterial.Label { text: "enabled" }
+    }
+
+    Column
+    {
+      spacing: Qaterial.Style.smallSpacing
+
+      Qaterial.Icon
+      {
+        anchors.horizontalCenter: parent.horizontalCenter
+        icon: Qaterial.Icons.abacus
+        enabled: false
+      }
+
+      Qaterial.Label { text: "disabled" }
+    }
+  }
+
+  Row
+  {
+    anchors.horizontalCenter: parent.horizontalCenter
+
+    spacing: Qaterial.Style.largeSpacing
+
+    Column
+    {
+      anchors.bottom: parent.bottom
+
+      spacing: Qaterial.Style.smallSpacing
+
+      Qaterial.Icon
+      {
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        icon: Qaterial.Icons.accountHardHat
+        color: Qaterial.Colors.red
+        size: Qaterial.Style.smallIcon
+
+        Qaterial.DebugRectangle { anchors.fill: parent }
+      }
+
+      Qaterial.Label
+      {
+        anchors.horizontalCenter: parent.horizontalCenter
+        text: "small"
+      }
+    }
+
+    Column
+    {
+      anchors.bottom: parent.bottom
+
+      spacing: Qaterial.Style.smallSpacing
+
+      Qaterial.Icon
+      {
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        icon: Qaterial.Icons.accountHardHat
+        color: Qaterial.Colors.green
+        size: Qaterial.Style.mediumIcon
+
+        Qaterial.DebugRectangle { anchors.fill: parent }
+      }
+
+
+      Qaterial.Label
+      {
+        anchors.horizontalCenter: parent.horizontalCenter
+        text: "medium"
+      }
+    }
+
+    Column
+    {
+      anchors.bottom: parent.bottom
+
+      spacing: Qaterial.Style.smallSpacing
+
+      Qaterial.Icon
+      {
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        icon: Qaterial.Icons.accountHardHat
+        color: Qaterial.Colors.blue
+        size: Qaterial.Style.largeIcon
+
+        Qaterial.DebugRectangle { anchors.fill: parent }
+      }
+
+      Qaterial.Label
+      {
+        anchors.horizontalCenter: parent.horizontalCenter
+        text: "large"
+      }
+    }
+  }
+}

--- a/qml/Qaterial/Icon.qml
+++ b/qml/Qaterial/Icon.qml
@@ -5,7 +5,7 @@
 
 // Qt
 import QtQuick 2.12
-import QtGraphicalEffects 1.12
+import QtGraphicalEffects 1.12 as QGE
 
 import Qaterial 1.0 as Qaterial
 
@@ -13,12 +13,13 @@ Item
 {
   id: root
 
-  property color color: Qaterial.Style.primaryTextColor()
+  property color color: enabled ? Qaterial.Style.colorTheme.primaryText : Qaterial.Style.colorTheme.disabledText
   property alias icon: dummyImage.source
-  property real size: 24
-  property alias cached: iconOverlay.cached
+  property real size: Qaterial.Style.smallIcon
+  property bool cached: true
 
   readonly property real _implicitSize: icon.toString() ? size : 0
+  readonly property bool isImage: color.a === 0
 
   implicitWidth: _implicitSize
   implicitHeight: _implicitSize
@@ -31,19 +32,30 @@ Item
 
     fillMode: Image.PreserveAspectFit
     sourceSize: Qt.size(root.width, root.height)
-    visible: false
+    visible: root.isImage && root.enabled
   } // Image
 
-  ColorOverlay
+  QGE.ColorOverlay
   {
-    id: iconOverlay
-
-    anchors.fill: dummyImage
+    anchors.fill: parent
 
     source: dummyImage
     color: Qt.rgba(root.color.r, root.color.g, root.color.b, 1)
-    cached: true
+
+    cached: root.cached
+    visible: !root.isImage
   } // ColorOverlay
 
-  opacity: color.a
+  QGE.Colorize
+  {
+    anchors.fill: parent
+
+    source: dummyImage
+    hue: 0
+    saturation: 0
+    lightness: 0
+
+    cached: root.cached
+    visible: root.isImage && !root.enabled
+  } // Colorize
 } // Item

--- a/qml/Qaterial/Style.qml
+++ b/qml/Qaterial/Style.qml
@@ -82,6 +82,10 @@ Qaterial.Theme
   // amount of spacing that should be used inside bigger UI elements, for example between an icon and the corresponding text.
   property double largeSpacing: dense ? 12 : 16
 
+  property double smallIcon: dense ? 20 : 24
+  property double mediumIcon: dense ? 28 : 32
+  property double largeIcon: dense ? 36 : 40
+
   property color primaryColorLight: "white"
   property color primaryColorDark: "#202225" //"#212121"
   property color accentColorLight: "#FFC107"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17255804/118131081-5be91880-b3fe-11eb-91cf-ba8179c5446b.png)
✨ Icon: Icon can now display the original image, if color is set to transparent.
Default color also change to disabledText when Icon is disabled.
When image is disabled, Colorize effect is used to render in grayscale the image.
This commit make way easier to use the same higher components and using either an image or an icon.
✨ Style: Introduce smallIcon/mediumIcon/largeIcon