### PR TITLE
♻️ Only set Qt::AA_EnableHighDpiScaling for Qt5

### DIFF
--- a/src/Qaterial/Details/HighDpiFix.cpp
+++ b/src/Qaterial/Details/HighDpiFix.cpp
@@ -37,7 +37,10 @@ class HighDpiFix
         ::SetProcessDPIAware();
 #    endif
 #endif // Q_OS_WIN
+
+#if QT_VERSION_MAJOR < 6 // AA_EnableHighDpiScaling is enabled by default on qt6
         QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
     }
     static HighDpiFix singleton;
 };


### PR DESCRIPTION
AA_EnableHighDpiScaling is enabled by default on qt6
merged from : https://github.com/OlivierLDff/Qaterial/pull/111
Thanks to @moodyhunter