### PR TITLE
🐛 Fix TextArea.onTextChanged not emitted properly

### DIFF
--- a/qml/Qaterial/TextArea.qml
+++ b/qml/Qaterial/TextArea.qml
@@ -384,6 +384,7 @@ Control
     leftPadding: _control.virtualLeftPadding + (_control.prefixText != "" ? _prefixLabel.contentWidth + _control
       .textSpacing : 0)
 
+    onTextChanged: () => _control.text = text
     onEditingFinished: _control.editingFinished()
     onLinkActivated: _control.linkActivated(link)
     onLinkHovered: _control.linkHovered(link)


### PR DESCRIPTION
This fix is temporary. TextArea require entire refactor instead of ugly hack
fix https://github.com/OlivierLDff/Qaterial/issues/114
Thanks to @moodyhunter