### PR TITLE
⬆️ QOlm v3.2.0

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -17,7 +17,7 @@ set(GOOGLEFONTS_TAG "0cdadf80ac5f29f10a73c29ce1f4f1ca75ffb392" CACHE STRING "Goo
 ## C++ libraries
 
 set(QOLM_REPOSITORY "https://github.com/OlivierLDff/QOlm.git" CACHE STRING "QOlm repository url")
-set(QOLM_TAG "v3.1.4" CACHE STRING "QOlm git tag")
+set(QOLM_TAG "v3.2.0" CACHE STRING "QOlm git tag")
 
 ## Ressources
 


### PR DESCRIPTION
### 3.2.0
💥 uniformize objectRemoved signal with objectInserted & objectMoved
This make sure that the object isn't present in list anymore when signal is emitted. This is way easier to deal with than about to be removed
📝 Add CPM & add_subdirectory install instruction
📝 Remove dependency note about eventpp

### 3.1.5
🔨 QOLM_VERBOSE if QOlm is main project 417559f
🔨 Disallow in source build 0d85845
🔨 Default build type to Release (CMAKE_BUILD_TYPE) b584c4e
🔨 Set global property USE_FOLDERS only if QOlm is main project ab92c69
🔨 Use standard CMAKE_INSTALL_INCLUDEDIR 53e1cff