### PR TITLE
🚑️ fix Material Design Icon path in CMake

### DIFF
--- a/cmake/FetchMaterialDesignIcons.cmake
+++ b/cmake/FetchMaterialDesignIcons.cmake
@@ -12,4 +12,4 @@ CPMAddPackage(
   GIT_TAG "7cc6cc10a0a77d2b23dced9247bd73850f57dc29"
 )
 
-set(MATERIALDESIGNICONS_ICONS_DIR "${materialdesignicons_SOURCE_DIR}/svg")
+set(MATERIALDESIGNICONS_ICONS_DIR "${MaterialDesignIcons_SOURCE_DIR}/svg")


### PR DESCRIPTION
This was resulting in no svg being embedded or generated in Qaterial