### PR TITLE
🐛 DialogManager showOpenFilesDialog correctly forward call

### DIFF
--- a/qml/Qaterial/DialogManager.qml
+++ b/qml/Qaterial/DialogManager.qml
@@ -35,7 +35,7 @@ QtObject
   function showOpenFilesDialog(settings)
   {
     if(dialogLoader)
-      dialogLoader.showOpenFileDialog(settings)
+      dialogLoader.showOpenFilesDialog(settings)
   }
 
   function showFolderDialog(settings)


### PR DESCRIPTION
Before, showOpenFilesDialog was calling showOpenFileDialog.