### PR TITLE
🐛 Fix `QATERIAL_ENABLE_ICONS=OFF` in CMake config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,16 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         version: ['5.15.2']
+        include:
+          - os: ubuntu-latest
+            enable_icons: 'ON'
+          - os: ubuntu-latest
+            enable_icons: 'OFF'
+          - os: macOS-latest
+            enable_icons: 'ON'
+          - os: windows-latest
+            enable_icons: 'ON'
+
     steps:
       -
         uses: actions/checkout@v2
@@ -41,6 +51,7 @@ jobs:
           cmake -E make_directory build
           cmake                           \
             -DQATERIAL_ENABLE_TESTS=ON    \
+            -DQATERIAL_ENABLE_ICONS=${{ matrix.enable_icons }} \
             -DCMAKE_BUILD_TYPE="Release"  \
             -DCPM_SOURCE_CACHE=.cpm       \
             -B build                      \

--- a/cmake/QaterialGenerateIcons.cmake
+++ b/cmake/QaterialGenerateIcons.cmake
@@ -200,8 +200,8 @@ function(qaterial_generate_icons_class OUTPUT_FILE_HPP OUTPUT_FILE_CPP)
   else()
 
     # Generate fake Qaterial.Impl.Icons.Icons.qml
-    message(STATUS "Generate Fake ${OUTPUT_FILE}")
-    file(WRITE ${OUTPUT_FILE}
+    message(STATUS "Generate Fake ${OUTPUT_FILE_HPP}")
+    file(WRITE ${OUTPUT_FILE_HPP}
       "// Dummy file generated with CMake to mock the absence of Mdi icons.\n"
       "// Everything written here will be lost.\n\n"
       "#ifndef __QATERIAL_ICONS_HPP__\n"
@@ -219,6 +219,13 @@ function(qaterial_generate_icons_class OUTPUT_FILE_HPP OUTPUT_FILE_CPP)
       "};\n\n"
       "}\n\n"
       "#endif"
+    )
+
+    # Generate fake Qaterial.Impl.Icons.Icons.cpp
+    message(STATUS "Generate Fake ${OUTPUT_FILE_CPP}")
+    file(WRITE ${OUTPUT_FILE_CPP}
+      "// Dummy file generated with CMake to mock the absence of Mdi icons.\n"
+      "// Everything written here will be lost.\n\n"
     )
 
   endif()

--- a/cmake/QaterialGenerateIcons.cmake
+++ b/cmake/QaterialGenerateIcons.cmake
@@ -199,7 +199,6 @@ function(qaterial_generate_icons_class OUTPUT_FILE_HPP OUTPUT_FILE_CPP)
 
   else()
 
-    # Generate fake Qaterial.Impl.Icons.Icons.qml
     message(STATUS "Generate Fake ${OUTPUT_FILE_HPP}")
     file(WRITE ${OUTPUT_FILE_HPP}
       "// Dummy file generated with CMake to mock the absence of Mdi icons.\n"
@@ -221,11 +220,16 @@ function(qaterial_generate_icons_class OUTPUT_FILE_HPP OUTPUT_FILE_CPP)
       "#endif"
     )
 
-    # Generate fake Qaterial.Impl.Icons.Icons.cpp
     message(STATUS "Generate Fake ${OUTPUT_FILE_CPP}")
     file(WRITE ${OUTPUT_FILE_CPP}
       "// Dummy file generated with CMake to mock the absence of Mdi icons.\n"
       "// Everything written here will be lost.\n\n"
+      "#include <Qaterial/Display/Icons.hpp>\n"
+      "#include \"moc_Icons.cpp\"\n"
+      "void __Qaterial_registerIconsSingleton()\n"
+      "{\n"
+      "    qaterial::Icons::registerSingleton();\n"
+      "}\n"
     )
 
   endif()


### PR DESCRIPTION
This add in the CI a check to test this config.
Fixes #150 