### PR TITLE
🔧 CMakePresets: Always set `binaryDir`

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,6 +9,7 @@
         {
             "name": "base-dev",
             "hidden": true,
+            "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
                 "CMAKE_EXPORT_COMPILE_COMMANDS": true,
                 "CPM_SOURCE_CACHE": "${sourceDir}/.cpm",
@@ -20,7 +21,6 @@
             "name": "base-dev-ninja",
             "hidden": true,
             "inherits": "base-dev",
-            "binaryDir": "${sourceDir}/build/${presetName}",
             "generator": "Ninja",
             "cacheVariables": {
                 "USE_CCACHE": true
@@ -65,7 +65,6 @@
             "name": "msvc-16",
             "inherits": "base-dev",
             "displayName": "Visual Studio 2019",
-            "binaryDir": "${sourceDir}/build/${presetName}",
             "generator": "Visual Studio 16 2019",
             "description": "Build Visual Studio 16 2019 generator",
             "condition": {
@@ -78,7 +77,6 @@
             "name": "msvc-17",
             "inherits": "base-dev",
             "displayName": "Visual Studio 2022",
-            "binaryDir": "${sourceDir}/build/${presetName}",
             "generator": "Visual Studio 17 2022",
             "description": "Build Visual Studio 17 2022 generator",
             "condition": {


### PR DESCRIPTION
`ninja-multi` was doing in source build
